### PR TITLE
Add helper function for matching CanFulfill Intent name

### DIFF
--- a/ask-sdk-core/ask_sdk_core/utils/__init__.py
+++ b/ask-sdk-core/ask_sdk_core/utils/__init__.py
@@ -18,7 +18,7 @@
 import sys
 
 from ..__version__ import __version__
-from .predicate import is_intent_name, is_request_type
+from .predicate import is_canfulfill_intent_name, is_intent_name, is_request_type
 from ask_sdk_runtime.utils import user_agent_info
 
 

--- a/ask-sdk-core/ask_sdk_core/utils/predicate.py
+++ b/ask-sdk-core/ask_sdk_core/utils/predicate.py
@@ -18,10 +18,36 @@
 import typing
 
 from ask_sdk_model import IntentRequest
+from ask_sdk_model.canfulfill import CanFulfillIntentRequest
 
 if typing.TYPE_CHECKING:
     from typing import Callable
     from ..handler_input import HandlerInput
+
+
+def is_canfulfill_intent_name(name):
+    # type: (str) -> Callable[[HandlerInput], bool]
+    """A predicate function returning a boolean, when name matches the
+    intent name in a CanFulfill Intent Request.
+
+    The function can be applied on a
+    :py:class:`ask_sdk_core.handler_input.HandlerInput`, to
+    check if the input is of
+    :py:class:`ask_sdk_model.intent_request.CanFulfillIntentRequest` type and if the
+    name of the request matches with the passed name.
+
+    :param name: Name to be matched with the CanFulfill Intent Request Name
+    :type name: str
+    :return: Predicate function that can be used to check name of the
+        request
+    :rtype: Callable[[HandlerInput], bool]
+    """
+    def can_handle_wrapper(handler_input):
+        # type: (HandlerInput) -> bool
+        return (isinstance(
+            handler_input.request_envelope.request, CanFulfillIntentRequest) and
+                handler_input.request_envelope.request.intent.name == name)
+    return can_handle_wrapper
 
 
 def is_intent_name(name):

--- a/ask-sdk-core/tests/unit/test_utils.py
+++ b/ask-sdk-core/tests/unit/test_utils.py
@@ -20,11 +20,60 @@ import random
 
 from ask_sdk_model import (
     IntentRequest, RequestEnvelope, Intent, SessionEndedRequest, Context)
+from ask_sdk_model.canfulfill import CanFulfillIntentRequest
 from ask_sdk_core.utils import (
-    is_intent_name, is_request_type, viewport)
+    is_canfulfill_intent_name, is_intent_name, is_request_type, viewport)
 from ask_sdk_core.handler_input import HandlerInput
 from ask_sdk_core.exceptions import AskSdkException
 from ask_sdk_model.interfaces.viewport import ViewportState, Shape
+
+
+def test_is_canfulfill_intent_name_match():
+    test_canfulfill_intent_name = "TestIntent"
+    test_handler_input = HandlerInput(
+        request_envelope=RequestEnvelope(request=CanFulfillIntentRequest(
+            intent=Intent(name=test_canfulfill_intent_name))))
+
+    canfulfill_intent_name_wrapper = is_canfulfill_intent_name(test_canfulfill_intent_name)
+    assert canfulfill_intent_name_wrapper(
+        test_handler_input), "is_canfulfill_intent_name matcher didn't match with the " \
+                             "correct intent name"
+
+
+def test_is_canfulfill_intent_name_not_match():
+    test_canfulfill_intent_name = "TestIntent"
+    test_handler_input = HandlerInput(
+        request_envelope=RequestEnvelope(request=CanFulfillIntentRequest(
+            intent=Intent(name=test_canfulfill_intent_name))))
+
+    canfulfill_intent_name_wrapper = is_canfulfill_intent_name("TestIntent1")
+    assert not canfulfill_intent_name_wrapper(
+        test_handler_input), "is_canfulfill_intent_name matcher matched with the " \
+                             "incorrect intent name"
+
+
+def test_is_canfulfill_intent_not_match_intent():
+    test_canfulfill_intent_name = "TestIntent"
+    test_canfulfill_handler_input = HandlerInput(
+        request_envelope=RequestEnvelope(request=CanFulfillIntentRequest(
+            intent=Intent(name=test_canfulfill_intent_name))))
+
+    intent_name_wrapper = is_intent_name(test_canfulfill_intent_name)
+    assert not intent_name_wrapper(
+        test_canfulfill_handler_input), "is_intent_name matcher matched with the " \
+                                        "incorrect request type"
+
+
+def test_is_intent_not_match_canfulfill_intent():
+    test_intent_name = "TestIntent"
+    test_handler_input = HandlerInput(
+        request_envelope=RequestEnvelope(request=IntentRequest(
+            intent=Intent(name=test_intent_name))))
+
+    canfulfill_intent_name_wrapper = is_canfulfill_intent_name(test_intent_name)
+    assert not canfulfill_intent_name_wrapper(
+        test_handler_input), "is_canfulfill_intent_name matcher matched with the " \
+                             "incorrect request type"
 
 
 def test_is_intent_name_match():
@@ -344,5 +393,3 @@ class TestViewportProfile(unittest.TestCase):
         assert (viewport.get_viewport_profile(test_request_env)
                 is viewport.ViewportProfile.UNKNOWN_VIEWPORT_PROFILE), (
             "Viewport profile couldn't resolve UNKNOWN_VIEWPORT_PROFILE")
-
-


### PR DESCRIPTION
## Description
Provide matching helper function for `IntentRequest`-specific `is_intent_name()` to `CanFulfillIntentRequest`... for use in `can_handle()`.

## Motivation and Context
Follow DRY principles.
Simply intent matching. 

i.e., 
```
return (
    is_request_type('CanFulfillIntentRequest')(handler_input) and
    handler_input.request_envelope.request.intent.name == 'MyIntent'
)
```
to...
```
return is_canfulfill_intent_name('MyIntent')(handler_input)
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
