### PR TITLE
Deserialize only if payload is not None

### DIFF
--- a/ask-sdk-core/ask_sdk_core/serialize.py
+++ b/ask-sdk-core/ask_sdk_core/serialize.py
@@ -143,6 +143,9 @@ class DefaultSerializer(Serializer):
         :return: deserialized object
         :rtype: T
         """
+        if payload is None:
+            return None
+
         if type(obj_type) == str:
             if obj_type.startswith('list['):
                 # Get object type for each item in the list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR involves adding a check on the `deserialize` method, to only deserialize if the payload is not None. This check was present on the `DefaultSerializer.deserialize` method, which will only check the top level but do not check the values recursively. This fix will check the recursive values inside the JSON before deserializing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
This change was because of issue #47 . Effectively, [Alexa GetList](https://developer.amazon.com/docs/custom-skills/access-the-alexa-shopping-and-to-do-lists.html#getList) API provides a list with attribute `links` as null, but the SDK expects it to be a list of values.  

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Tried the following code snippet to be working as expected, after the fix : 

`class LaunchRequestHandler(AbstractRequestHandler):
    """Handler for skill launch."""
    def can_handle(self, handler_input):
        # type: (HandlerInput) -> bool
        return is_request_type("LaunchRequest")(handler_input)

    def handle(self, handler_input):
        # type: (HandlerInput) -> Response
        logger.info("In LaunchRequestHandler")
        speech = 'Get Lists metadata'

        req_envelope = handler_input.request_envelope
        response_builder = handler_input.response_builder
        service_client_fact = handler_input.service_client_factory

        if not (req_envelope.context.system.user.permissions and
                req_envelope.context.system.user.permissions.consent_token):
            response_builder.speak(NOTIFY_MISSING_PERMISSIONS)
            print('starting handler12')
            response_builder.set_card(
                AskForPermissionsConsentCard(permissions=permissions))
            return response_builder.response


        device_id = req_envelope.context.system.device.device_id
        device_list_client = service_client_fact.get_list_management_service()
        device_list_client.get_list(<valid list id>, 'active')
`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [] I have updated the documentation accordingly
- [x] I have read the **README** document
- [] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
