### PR TITLE
Makes attribute_map optional for serializing

### DIFF
--- a/ask-sdk-core/ask_sdk_core/serialize.py
+++ b/ask-sdk-core/ask_sdk_core/serialize.py
@@ -67,8 +67,8 @@ class DefaultSerializer(Serializer):
         If obj is list, serialize each element in the list.
         If obj is dict, return the dict with serialized values.
         If obj is ask sdk model, return the dict with keys resolved
-        from model's ``attribute_map`` and values serialized
-        based on ``deserialized_types``.
+        from the union of model's ``attribute_map`` and ``deserialized_types``
+        and values serialized based on ``deserialized_types``.
 
         :param obj: The data to serialize.
         :type obj: object

--- a/ask-sdk-core/tests/unit/data/model_test_object_3.py
+++ b/ask-sdk-core/tests/unit/data/model_test_object_3.py
@@ -16,12 +16,16 @@
 # License.
 #
 
-from .model_enum_object import ModelEnumObject
-from .model_test_object_1 import ModelTestObject1
-from .model_test_object_2 import ModelTestObject2
-from .model_test_object_3 import ModelTestObject3
-from .model_test_object_4 import ModelTestObject4
-from .invalid_model_object import InvalidModelObject
-from .model_abstract_parent_object import ModelAbstractParentObject
-from .model_child_objects import ModelChildObject1
-from .model_child_objects import ModelChildObject2
+
+class ModelTestObject3(object):
+    deserialized_types = {
+        'str_var': 'str',
+        'int_var': 'int'
+    }
+
+    def __init__(self, str_var=None, int_var=None):
+        self.str_var = str_var
+        self.int_var = int_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-core/tests/unit/data/model_test_object_4.py
+++ b/ask-sdk-core/tests/unit/data/model_test_object_4.py
@@ -16,12 +16,20 @@
 # License.
 #
 
-from .model_enum_object import ModelEnumObject
-from .model_test_object_1 import ModelTestObject1
-from .model_test_object_2 import ModelTestObject2
-from .model_test_object_3 import ModelTestObject3
-from .model_test_object_4 import ModelTestObject4
-from .invalid_model_object import InvalidModelObject
-from .model_abstract_parent_object import ModelAbstractParentObject
-from .model_child_objects import ModelChildObject1
-from .model_child_objects import ModelChildObject2
+
+class ModelTestObject4(object):
+    deserialized_types = {
+        'str_var': 'str',
+        'float_var': 'float'
+    }
+
+    attribute_map = {
+        'float_var': 'floatingValue'
+    }
+
+    def __init__(self, str_var=None, float_var=None):
+        self.str_var = str_var
+        self.float_var = float_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-core/tests/unit/test_serialize.py
+++ b/ask-sdk-core/tests/unit/test_serialize.py
@@ -132,6 +132,24 @@ class TestSerialization(unittest.TestCase):
         assert self.test_serializer.serialize(test_model_obj_1) == expected_serialized_obj, \
             "Default Serializer serialized model object incorrectly"
 
+    def test_model_obj_without_attrmap_serialization(self):
+        test_obj_inst = data.ModelTestObject3(str_var="test", int_var=123)
+        expected_dict = {
+            "str_var": "test",
+            "int_var": 123
+        }
+        assert self.test_serializer.serialize(test_obj_inst) == expected_dict, \
+            "Default Serializer serialized object without attribute_map incorrectly"
+
+    def test_model_obj_with_incomplete_attrmap_serialization(self):
+        test_obj_inst = data.ModelTestObject4(str_var="test", float_var=3.14)
+        expected_dict = {
+            "str_var": "test",
+            "floatingValue": 3.14
+        }
+        assert self.test_serializer.serialize(test_obj_inst) == expected_dict, \
+            "Default Serializer serialized object with incomplete attribute map incorrectly"
+
     def test_enum_obj_serialization(self):
         test_model_obj_2 = data.ModelTestObject2(int_var=123)
         test_enum_obj = data.ModelEnumObject("ENUM_VAL_1")
@@ -405,6 +423,34 @@ class TestDeserialization(unittest.TestCase):
             assert self.test_serializer.deserialize(
                 test_payload, test_obj_type) == expected_obj, (
                 "Default Serializer deserialized model object incorrectly when payload has additional parameters")
+
+    def test_model_obj_without_attrmap_deserialization(self):
+        test_payload = {
+            "str_var": "Test",
+            "int_var": 123
+        }
+        test_obj_type = data.ModelTestObject3
+        expected_obj = data.ModelTestObject3(str_var="Test", int_var=123)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object without attribute map incorrectly")
+
+    def test_model_obj_with_incomplete_attrmap_deserialization(self):
+        test_payload = {
+            "str_var": "Test",
+            "floatingValue": 3.14
+        }
+        test_obj_type = data.ModelTestObject4
+        expected_obj = data.ModelTestObject4(str_var="Test", float_var=3.14)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object with incomplete attribute map incorrectly")
 
     def test_invalid_model_obj_deserialization(self):
         test_payload = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of having duplicated keys between `attribute_map` and `deserialized_types`, this PR allows to completely leave out `attribute_map` in serialized classes, if you don't want to do any renaming between the native and serialized representations.

An example:
```python
class User:
    deserialized_types = {
        'name': 'str',
        'age': 'int'
    }

    def __init__(self, name='', age=0):
        self.name = name
        self.age = age

u = User('joe', 42)
serializer = DefaultSerializer()
serializer.serialize(u) # {'name': 'joe', 'age': 42}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

This PR is a follow-up on the discussion in #58. I'm using the serializer in my projects too, as I found it super useful. However I found the repetition of attribute names unnecessary and decreasing the readability of my models.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
I ran the tests locally (OS X, py3.6), all passed. Note I didn't add new tests to cover this functionality as it is only in discussion/evaluation phase. I'm happy to add some if you find the change acceptable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
