### PR TITLE
Add PlayBehavior optional parameter on response builder speak, ask methods

### DIFF
--- a/ask-sdk-core/ask_sdk_core/response_helper.py
+++ b/ask-sdk-core/ask_sdk_core/response_helper.py
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
     from ask_sdk_model import Directive
     from ask_sdk_model.ui import Card
     from ask_sdk_model.canfulfill import CanFulfillIntent
+    from ask_sdk_model.ui.play_behavior import PlayBehavior
 
 
 PLAIN_TEXT_TYPE = "PlainText"
@@ -51,23 +52,27 @@ class ResponseFactory(object):
             directives=None, should_end_session=None,
             can_fulfill_intent=None)
 
-    def speak(self, speech):
-        # type: (str) -> 'ResponseFactory'
+    def speak(self, speech, play_behavior=None):
+        # type: (str, PlayBehavior) -> 'ResponseFactory'
         """Say the provided speech to the user.
 
         :param speech: the output speech sent back to the user.
         :type speech: str
+        :param play_behavior: attribute to control alexa's speech
+            interruption
+        :type play_behavior: ask_sdk_model.ui.play_behavior.PlayBehavior
         :return: response factory with partial response being built and
             access from self.response.
         :rtype: ResponseFactory
         """
         ssml = "<speak>{}</speak>".format(self.__trim_outputspeech(
             speech_output=speech))
-        self.response.output_speech = SsmlOutputSpeech(ssml=ssml)
+        self.response.output_speech = SsmlOutputSpeech(
+            ssml=ssml, play_behavior=play_behavior)
         return self
 
-    def ask(self, reprompt):
-        # type: (str) -> 'ResponseFactory'
+    def ask(self, reprompt, play_behavior=None):
+        # type: (str, PlayBehavior) -> 'ResponseFactory'
         """Provide reprompt speech to the user, if no response for
         8 seconds.
 
@@ -76,13 +81,17 @@ class ResponseFactory(object):
 
         :param reprompt: the output speech to reprompt.
         :type reprompt: str
+        :param play_behavior: attribute to control alexa's speech
+            interruption
+        :type play_behavior: ask_sdk_model.ui.play_behavior.PlayBehavior
         :return: response factory with partial response being built and
             access from self.response.
         :rtype: ResponseFactory
         """
         ssml = "<speak>{}</speak>".format(self.__trim_outputspeech(
             speech_output=reprompt))
-        output_speech = SsmlOutputSpeech(ssml=ssml)
+        output_speech = SsmlOutputSpeech(
+            ssml=ssml, play_behavior=play_behavior)
         self.response.reprompt = Reprompt(output_speech=output_speech)
         if not self.__is_video_app_launch_directive_present():
             self.response.should_end_session = False

--- a/ask-sdk-core/tests/unit/test_response_helper.py
+++ b/ask-sdk-core/tests/unit/test_response_helper.py
@@ -26,6 +26,7 @@ from ask_sdk_model.interfaces.display import RichText
 from ask_sdk_model.canfulfill import (
     CanFulfillIntent, CanFulfillIntentValues, CanFulfillSlot,
     CanFulfillSlotValues, CanUnderstandSlotValues)
+from ask_sdk_model.ui.play_behavior import PlayBehavior
 
 from ask_sdk_core.response_helper import (
     ResponseFactory, get_text_content, get_plain_text_content,
@@ -43,6 +44,16 @@ class TestResponseFactory(unittest.TestCase):
             ssml="<speak></speak>"), (
             "The speak method of ResponseFactory fails to set output speech")
 
+    def test_speak_with_play_behavior(self):
+        test_play_behavior = PlayBehavior.ENQUEUE
+        response_factory = self.response_factory.speak(
+            speech=None, play_behavior=test_play_behavior)
+
+        assert response_factory.response.output_speech == SsmlOutputSpeech(
+            ssml="<speak></speak>", play_behavior=test_play_behavior), (
+            "The speak method of ResponseFactory fails to set play behavior "
+            "on output speech")
+
     def test_ask(self):
         response_factory = self.response_factory.ask(reprompt=None)
 
@@ -52,6 +63,18 @@ class TestResponseFactory(unittest.TestCase):
         assert response_factory.response.should_end_session is False, (
             "The ask method of ResponseFactory fails to set the "
             "should_end_session to False")
+
+    def test_ask_with_play_behavior(self):
+        test_play_behavior = PlayBehavior.REPLACE_ALL
+        response_factory = self.response_factory.ask(
+            reprompt=None, play_behavior=test_play_behavior)
+
+        assert response_factory.response.reprompt == Reprompt(
+            output_speech=SsmlOutputSpeech(
+                ssml="<speak></speak>",
+                play_behavior=test_play_behavior)), (
+            "The ask method of ResponseFactory fails to set play behavior "
+            "on reprompt output speech")
 
     def test_ask_with_video_app_launch_directive(self):
         directive = LaunchDirective(video_item=VideoItem(


### PR DESCRIPTION
Add PlayBehavior optional parameter on response builder speak, ask methods

This commit includes the optional parameter play_behavior on ResponseFactory's
speak and ask methods, to include the Speech Interruption property
PlayBehavior as mentioned in the [Alexa Response structure definition](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html#outputspeech-object).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
`PlayBehavior` attribute on Alexa `Response` provides a way to interrupt Alexa speech, which is useful during some skill development like game skills. Since Response Builder is the SDK's way of generating the response, we need to provide a way to add this attribute on the `speak` and `ask` commands of the builder, for skill developers to use.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Added tests, tox works fine.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
