### PR TITLE
Change default api client request body serialization

### DIFF
--- a/ask-sdk-core/ask_sdk_core/api_client.py
+++ b/ask-sdk-core/ask_sdk_core/api_client.py
@@ -67,7 +67,12 @@ class DefaultApiClient(ApiClient):
                     "Requests against non-HTTPS endpoints are not allowed.")
 
             if request.body:
-                raw_data = json.dumps(request.body)
+                body_content_type = http_headers.get("Content-type", None)
+                if (body_content_type is not None and
+                        "json" in body_content_type):
+                    raw_data = json.dumps(request.body)
+                else:
+                    raw_data = request.body
             else:
                 raw_data = None
 

--- a/ask-sdk-core/tests/unit/test_api_client.py
+++ b/ask-sdk-core/tests/unit/test_api_client.py
@@ -184,7 +184,26 @@ class TestDefaultApiClient(unittest.TestCase):
 
             assert "Requests against non-HTTPS endpoints are not allowed." in str(exc.exception)
 
-    def test_api_client_send_request_with_raw_data(self):
+    def test_api_client_send_request_with_raw_data_serialized_for_json_content(
+            self):
+        test_data = "test\nstring"
+        self.valid_request.body = "test\nstring"
+        self.valid_request.method = "POST"
+        headers = [("Content-type", "application/json")]
+        self.valid_request.headers = headers
+
+        with mock.patch(
+                "requests.post",
+                side_effect=lambda *args, **kwargs: self.valid_mock_response
+        ) as mock_put:
+            actual_response = self.test_api_client.invoke(self.valid_request)
+            mock_put.assert_called_once_with(
+                data=json.dumps(test_data),
+                headers={'Content-type': 'application/json'},
+                url=self.valid_request.url)
+
+    def test_api_client_send_request_with_raw_data_unchanged_for_non_json_content(
+            self):
         test_data = "test\nstring"
         self.valid_request.body = "test\nstring"
         self.valid_request.method = "POST"
@@ -195,5 +214,5 @@ class TestDefaultApiClient(unittest.TestCase):
         ) as mock_put:
             actual_response = self.test_api_client.invoke(self.valid_request)
             mock_put.assert_called_once_with(
-                data=json.dumps(test_data), headers={},
+                data=test_data, headers={},
                 url=self.valid_request.url)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit makes a change in the default api client - request body
serialization. The earlier code has a conversion for the request
body to convert to json before triggering the APIs, without checking
the content type of the request. This would make incorrect API calls
if the request body is not of type JSON. This commit checks if the
request body content is of type json and only convert it. If not,
then send in the body unconverted, leaving the initial input as is.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
To allow default api client, to call Alexa-APIs that has other than `application/json` body content

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Corresponding tests has been added to the default api client test suite. tox tests are successful.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
