### PR TITLE
Set custom user agent correctly, run webservice tests on tox

### DIFF
--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/__version__.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/__version__.py
@@ -19,7 +19,7 @@ __pip_package_name__ = 'ask-sdk-webservice-support'
 __description__ = ('The ASK SDK Webservice package provides support for '
                    'running skills, built using the Alexa Skills Kit '
                    'SDK, as web applications.')
-__url__ = 'https://github.com/alexa-labs/ask-sdk-python-playground'
+__url__ = 'https://github.com/alexa/alexa-skills-kit-sdk-for-python'
 __version__ = '0.1.1'
 __author__ = 'Alexa Skills Kit'
 __author_email__ = 'ask-sdk-dynamic@amazon.com'

--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/webservice_handler.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/webservice_handler.py
@@ -85,7 +85,7 @@ class WebserviceSkillHandler(object):
                 "Invalid skill instance provided. Expected a custom "
                 "skill instance.")
 
-        self._skill.custom_user_agent += " ask-webservice"
+        self._add_custom_user_agent("ask-webservice")
 
         if verify_signature:
             self._verifiers.append(RequestVerifier())
@@ -95,6 +95,23 @@ class WebserviceSkillHandler(object):
 
         if verifiers is not None:
             self._verifiers.extend(verifiers)
+
+    def _add_custom_user_agent(self, user_agent):
+        # type: (str) -> None
+        """Adds the user agent to the skill instance.
+
+        This method adds the passed in user_agent to the skill, which
+        is reflected in the skill's response envelope.
+
+        :param user_agent: Custom User Agent string provided by
+            the developer.
+        :type user_agent: str
+        :rtype: None
+        """
+        if self._skill.custom_user_agent is None:
+            self._skill.custom_user_agent = user_agent
+        else:
+            self._skill.custom_user_agent += " {}".format(user_agent)
 
     def verify_request_and_dispatch(
             self, http_request_headers, http_request_body):

--- a/ask-sdk-webservice-support/tests/unit/test_webservice_handler.py
+++ b/ask-sdk-webservice-support/tests/unit/test_webservice_handler.py
@@ -37,7 +37,7 @@ class TestWebserviceSkillHandler(unittest.TestCase):
         self.mock_skill = mock.MagicMock(spec=CustomSkill)
         self.mock_serializer = mock.MagicMock(spec=DefaultSerializer)
         self.mock_skill.serializer = self.mock_serializer
-        self.mock_skill.custom_user_agent = ""
+        self.mock_skill.custom_user_agent = None
         self.mock_verifier = mock.MagicMock(spec=AbstractVerifier)
 
     def test_webservice_skill_handler_init_invalid_skill_raise_exception(self):
@@ -49,14 +49,24 @@ class TestWebserviceSkillHandler(unittest.TestCase):
             "Webservice skill handler didn't raise TypError on "
             "initialization when an invalid skill instance is provided")
 
-    def test_webservice_skill_handler_init_add_custom_user_agent(self):
+    def test_webservice_skill_handler_init_create_custom_user_agent(self):
         WebserviceSkillHandler(skill=self.mock_skill, verify_signature=False,
                                verify_timestamp=False)
 
         self.assertEqual(
-            self.mock_skill.custom_user_agent, " ask-webservice",
+            self.mock_skill.custom_user_agent, "ask-webservice",
+            "Webservice skill handler didn't create new custom user agent "
+            "value for a valid custom skill without a user agent")
+
+    def test_webservice_skill_handler_init_append_custom_user_agent(self):
+        self.mock_skill.custom_user_agent = "test-value"
+        WebserviceSkillHandler(skill=self.mock_skill, verify_signature=False,
+                               verify_timestamp=False)
+
+        self.assertEqual(
+            self.mock_skill.custom_user_agent, "test-value ask-webservice",
             "Webservice skill handler didn't update custom user agent "
-            "for a valid custom skill")
+            "for a valid custom skill with an existing user agent")
 
     def test_webservice_skill_handler_init_with_no_verifiers(self):
         test_webservice_skill_handler = WebserviceSkillHandler(

--- a/django-ask-sdk/django_ask_sdk/__version__.py
+++ b/django-ask-sdk/django_ask_sdk/__version__.py
@@ -19,7 +19,7 @@ __pip_package_name__ = 'django-ask-sdk'
 __description__ = ('The Django ASK SDK package provides support '
                    'for using ASK SDK and Django, to deploy custom '
                    'skills as webservice')
-__url__ = 'https://github.com/alexa-labs/ask-sdk-python-playground'
+__url__ = 'https://github.com/alexa/alexa-skills-kit-sdk-for-python'
 __version__ = '0.1.0'
 __author__ = 'Alexa Skills Kit'
 __author_email__ = 'ask-sdk-dynamic@amazon.com'

--- a/django-ask-sdk/django_ask_sdk/skill_adapter.py
+++ b/django-ask-sdk/django_ask_sdk/skill_adapter.py
@@ -128,8 +128,6 @@ class SkillAdapter(View):
                 "Invalid skill instance provided. Expected a custom "
                 "skill instance.")
 
-        self._skill.custom_user_agent += " django-ask-sdk"
-
         if verifiers is None:
             verifiers = []
 
@@ -146,6 +144,8 @@ class SkillAdapter(View):
             verify_timestamp=verify_timestamp,
             verifiers=self._verifiers
         )
+        self._webservice_handler._add_custom_user_agent("django-ask-sdk")
+
         super(SkillAdapter, self).__init__()
 
     @method_decorator(csrf_exempt)

--- a/django-ask-sdk/tests/unit/test_skill_adapter.py
+++ b/django-ask-sdk/tests/unit/test_skill_adapter.py
@@ -41,7 +41,7 @@ class TestSkillAdapter(unittest.TestCase):
                 os.path.join(os.path.dirname(__file__), '..')))
         os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'unit.test_settings')
         self.mock_skill = mock.MagicMock(spec=CustomSkill)
-        self.mock_skill.custom_user_agent = ""
+        self.mock_skill.custom_user_agent = None
 
         test_http_request = mock.MagicMock(spec=HttpRequest)
         test_http_request.META = {}
@@ -60,14 +60,24 @@ class TestSkillAdapter(unittest.TestCase):
             "SkillAdapter constructor didn't throw exception for "
             "invalid skill input")
 
-    def test_add_custom_user_agent_to_valid_skill_initialization(self):
+    def test_create_custom_user_agent_to_valid_skill_initialization(self):
         SkillAdapter(skill=self.mock_skill, verify_signature=False,
                      verify_timestamp=False)
 
-        self.assertIn(
-            "django-ask-sdk", self.mock_skill.custom_user_agent,
+        self.assertEqual(
+            "ask-webservice django-ask-sdk", self.mock_skill.custom_user_agent,
             "SkillAdapter didn't update custom user agent "
-            "for a valid custom skill")
+            "for a valid custom skill without a user agent set")
+
+    def test_append_custom_user_agent_to_valid_skill_initialization(self):
+        self.mock_skill.custom_user_agent = "test-agent"
+        SkillAdapter(skill=self.mock_skill, verify_signature=False,
+                     verify_timestamp=False)
+
+        self.assertEqual(
+            "test-agent ask-webservice django-ask-sdk", self.mock_skill.custom_user_agent,
+            "SkillAdapter didn't update custom user agent "
+            "for a valid custom skill with a user agent set")
     
     def test_unset_verify_signature_on_init(self):
         test_skill_adapter = SkillAdapter(

--- a/flask-ask-sdk/flask_ask_sdk/__version__.py
+++ b/flask-ask-sdk/flask_ask_sdk/__version__.py
@@ -19,7 +19,7 @@ __pip_package_name__ = 'flask-ask-sdk'
 __description__ = ('The Flask ASK SDK package provides support '
                    'for using ASK SDK and Flask, to deploy custom '
                    'skills as webservice')
-__url__ = 'https://github.com/alexa-labs/ask-sdk-python-playground'
+__url__ = 'https://github.com/alexa/alexa-skills-kit-sdk-for-python'
 __version__ = '0.1.0'
 __author__ = 'Alexa Skills Kit'
 __author_email__ = 'ask-sdk-dynamic@amazon.com'

--- a/flask-ask-sdk/flask_ask_sdk/skill_adapter.py
+++ b/flask-ask-sdk/flask_ask_sdk/skill_adapter.py
@@ -148,8 +148,6 @@ class SkillAdapter(object):
                 "Invalid skill instance provided. Expected a custom "
                 "skill instance.")
 
-        self._skill.custom_user_agent += " flask-ask-sdk"
-
         if app is not None:
             self.init_app(app)
 
@@ -209,6 +207,8 @@ class SkillAdapter(object):
             verify_timestamp=current_app.config.get(
                 VERIFY_TIMESTAMP_APP_CONFIG, True),
             verifiers=verifiers)
+
+        self._webservice_handler._add_custom_user_agent("flask-ask-sdk")
 
     def dispatch_request(self):
         # type: () -> Response

--- a/scripts/ci/run_tests
+++ b/scripts/ci/run_tests
@@ -11,7 +11,11 @@ _dname = os.path.dirname
 
 sdk_packages = [
     "ask-sdk-runtime", "ask-sdk-core",
-    "ask-sdk-dynamodb-persistence-adapter", "ask-sdk"]
+    "ask-sdk-dynamodb-persistence-adapter", "ask-sdk",
+    "ask-sdk-webservice-support", "flask-ask-sdk"]
+
+if sys.version_info.major == 3:
+    sdk_packages.append("django-ask-sdk")
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
 

--- a/scripts/ci/sdk_install
+++ b/scripts/ci/sdk_install
@@ -2,6 +2,7 @@
 import os
 from subprocess import check_call
 import shutil
+import sys
 
 _dname = os.path.dirname
 
@@ -14,7 +15,11 @@ def run(command):
 
 sdk_packages = [
     "ask-sdk-runtime", "ask-sdk-core",
-    "ask-sdk-dynamodb-persistence-adapter", "ask-sdk"]
+    "ask-sdk-dynamodb-persistence-adapter", "ask-sdk",
+    "ask-sdk-webservice-support", "flask-ask-sdk"]
+
+if sys.version_info.major == 3:
+    sdk_packages.append("django-ask-sdk")
 
 run("pip install coverage")
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,5 +21,3 @@ commands =
     flake8 .
     {toxinidir}/scripts/ci/sdk_install
     {toxinidir}/scripts/ci/run_tests
-# TODO : Need to add commands to install and run tests around
-# webservice support packages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This commit contains the following changes :

- The custom user agent in webservice support and corresponding packages were being set on skill during initialization. The user agent value is not set until the skill is invoked, leading to a ValueError. This commit fixes this issues. Fixes #82
- Added webservice support and corresponding packages to install and run tests scripts, so that tox will run all package tests.
- Set the `url` values under the webservice and corresponding packages to the correct github repo, to reflect on PyPI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes #82 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Tox runs fine. Also tested using the sample code posted by the customer in issue #82 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
