### PR TITLE
Update os specific verifier constant path

### DIFF
--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier_constants.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier_constants.py
@@ -15,44 +15,45 @@
 # specific language governing permissions and limitations under the
 # License.
 #
+import os
 
 #: Header key to be used, to retrieve request header that contains the
 #: URL for the certificate chain needed to verify the request signature.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#checking-the-signature-of-the-request>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 SIGNATURE_CERT_CHAIN_URL_HEADER = "SignatureCertChainUrl"
 
 #: Header key to be used, to retrieve request header that contains the
 #: request signature.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#checking-the-signature-of-the-request>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 SIGNATURE_HEADER = "Signature"
 
 #: Case insensitive protocol to be checked on signature certificate url.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#cert-verify-signature-certificate-url>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 CERT_CHAIN_URL_PROTOCOL = "https"
 
 #: Case insensitive hostname to be checked on signature certificate url.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#cert-verify-signature-certificate-url>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 CERT_CHAIN_URL_HOSTNAME = "s3.amazonaws.com"
 
 #: Path presence to be checked on signature certificate url.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#cert-verify-signature-certificate-url>`__.
-CERT_CHAIN_URL_STARTPATH = "/echo.api/"
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
+CERT_CHAIN_URL_STARTPATH = "{0}echo.api{0}".format(os.path.sep)
 
 #: Port to be checked on signature certificate url.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#cert-verify-signature-certificate-url>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 CERT_CHAIN_URL_PORT = 443
 
 #: Domain presence check in Subject Alternative Names (SANs) of
 #: signing certificate.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#checking-the-signature-of-the-request>`__.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-signature>`__.
 CERT_CHAIN_DOMAIN = "echo-api.amazon.com"
 
 #: Character encoding used in the request.
 CHARACTER_ENCODING = "utf-8"
 
 #: Default allowable tolerance in request timestamp.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#timestamp>`__.
-DEFAULT_TIMESTAMP_TOLERANCE_IN_MILLIS = 30000
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-timestamp>`__.
+DEFAULT_TIMESTAMP_TOLERANCE_IN_MILLIS = 150000
 
 #: Maximum allowable tolerance in request timestamp.
 #: For more info, check `link <https://developer.amazon.com/docs/smapi/skill-events-in-alexa-skills.html#delivery-of-events-to-the-skill>`__.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit makes the verfier_constants path from posix path to os
specific path check, which helps in valid request verification in
other than posix os. This also fixes the docstring links to refer the correct sections. Additionally, it also sets the default tolerance value for timestamp verifier to 150 seconds as mentioned in the documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
This is the requested fix for PR #89 . Raising one for community review since the other PR is not yet changed.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
