### PR TITLE
Add speak_randomly to response_builder

### DIFF
--- a/ask-sdk-core/ask_sdk_core/response_helper.py
+++ b/ask-sdk-core/ask_sdk_core/response_helper.py
@@ -16,6 +16,7 @@
 # License.
 #
 
+import random
 import typing
 from ask_sdk_model import Response
 from ask_sdk_model.ui import SsmlOutputSpeech, Reprompt
@@ -23,7 +24,7 @@ from ask_sdk_model.interfaces.display import (
     TextContent, PlainText, RichText)
 
 if typing.TYPE_CHECKING:
-    from typing import Union
+    from typing import Union, List
     from ask_sdk_model import Directive
     from ask_sdk_model.ui import Card
     from ask_sdk_model.canfulfill import CanFulfillIntent
@@ -70,6 +71,22 @@ class ResponseFactory(object):
         self.response.output_speech = SsmlOutputSpeech(
             ssml=ssml, play_behavior=play_behavior)
         return self
+
+    def speak_randomly(self, speeches, play_behavior=None):
+        # type: (List[str], PlayBehavior) -> 'ResponseFactory'
+        """Say the randomly one of the provided speeches to the user.
+
+        :param speeches: the possible output speeches to sent back to the user.
+        :type speeches: List[str]
+        :param play_behavior: attribute to control alexa's speech
+            interruption
+        :type play_behavior: ask_sdk_model.ui.play_behavior.PlayBehavior
+        :return: response factory with partial response being built and
+            access from self.response.
+        :rtype: ResponseFactory
+        """
+        speech = random.choice(speeches)
+        return self.speak(speech, play_behavior)
 
     def ask(self, reprompt, play_behavior=None):
         # type: (str, PlayBehavior) -> 'ResponseFactory'

--- a/ask-sdk-core/tests/unit/test_response_helper.py
+++ b/ask-sdk-core/tests/unit/test_response_helper.py
@@ -54,6 +54,13 @@ class TestResponseFactory(unittest.TestCase):
             "The speak method of ResponseFactory fails to set play behavior "
             "on output speech")
 
+    def test_speak_randomly(self):
+        response_factory = self.response_factory.speak_randomly(speeches=[None, "Hello World"])
+
+        assert response_factory.response.output_speech in [SsmlOutputSpeech(ssml="<speak></speak>"),
+                                                           SsmlOutputSpeech(ssml="<speak>Hello World</speak>")], (
+            "The speak_randomly method of ResponseFactory fails to set one of the given speeches")
+
     def test_ask(self):
         response_factory = self.response_factory.ask(reprompt=None)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a method to response_builder which randomly chooses one of the given speeches as the output_speech.

## Motivation and Context
It makes it easier to add variability to your alexa skill.

## Testing
Tested with Python 3.6 and Python 2.7 and the requirements specified in requirements.txt + mock.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
