### PR TITLE
Change get_slot_value function to return None when slot is not present

### DIFF
--- a/ask-sdk-core/ask_sdk_core/utils/request_util.py
+++ b/ask-sdk-core/ask_sdk_core/utils/request_util.py
@@ -230,7 +230,6 @@ def get_slot_value(handler_input, slot_name):
     found here :
     https://developer.amazon.com/docs/custom-skills/request-types-reference.html#slot-object
 
-    If there is no such slot, then a :py:class:`ValueError` is raised.
     If the input request is not an
     :py:class:`ask_sdk_model.intent_request.IntentRequest`, a
     :py:class:`TypeError` is raised.
@@ -242,17 +241,14 @@ def get_slot_value(handler_input, slot_name):
     :type slot_name: str
     :return: Slot value for the provided slot if it exists
     :rtype: str
-    :raises: TypeError if the input is not an IntentRequest. ValueError is
-        slot doesn't exist
+    :raises: TypeError if the input is not an IntentRequest.
     """
     slot = get_slot(handler_input=handler_input, slot_name=slot_name)
 
     if slot is not None:
         return slot.value
 
-    raise ValueError(
-        "Provided slot {} doesn't exist in the input request".format(
-            slot_name))
+    return None
 
 
 def get_supported_interfaces(handler_input):

--- a/ask-sdk-core/tests/unit/test_utils.py
+++ b/ask-sdk-core/tests/unit/test_utils.py
@@ -612,15 +612,14 @@ class TestRequestUtils(unittest.TestCase):
             get_slot_value(
                 handler_input=test_input, slot_name=self.test_slot_name)
 
-    def test_get_slot_value_throws_exception_for_non_existent_slot(self):
+    def test_get_slot_value_returns_null_for_non_existent_slot(self):
         test_input = self._create_handler_input(
             request=self.test_intent_request)
 
-        with self.assertRaises(
-                ValueError,
-                msg="get_slot_value method didn't throw ValueError when an "
-                    "invalid slot name is passed"):
-            get_slot_value(handler_input=test_input, slot_name="some_slot")
+        slot_value = get_slot_value(
+            handler_input=test_input, slot_name="some_slot")
+        self.assertIsNone(slot_value, "get_slot_value didn't return null for"
+                                      "non existent slot value in request")
 
     def test_get_slot_value(self):
         test_input = self._create_handler_input(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change get_slot_value function to return None when slot is not present
## Description
Instead of throwing an error, it would be better to return null when the slot is not present in requestEnvelope. Thus developer don't need to check whether the slot is existed before calling this util function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See above description
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
Changed the unit test and all unit tests passed.
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
