### PR TITLE
Allow out-of-session requests

### DIFF
--- a/ask-sdk-core/ask_sdk_core/attributes_manager.py
+++ b/ask-sdk-core/ask_sdk_core/attributes_manager.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from .exceptions import AttributesManagerException
 
 if typing.TYPE_CHECKING:
-    from typing import Dict
+    from typing import Dict, Optional
     from ask_sdk_model import RequestEnvelope
 
 
@@ -103,11 +103,10 @@ class AttributesManager(object):
         self._persistence_attributes = {}  # type: Dict
         self._request_attributes = {}  # type: Dict
         if not self._request_envelope.session:
-            raise AttributesManagerException(
-                "Cannot get SessionAttributes from out of session request!")
+            self._session_attributes = None  # type: Optional[Dict]
         else:
             if not self._request_envelope.session.attributes:
-                self._session_attributes = {}  # type: Dict
+                self._session_attributes = {}
             else:
                 self._session_attributes = deepcopy(
                     request_envelope.session.attributes)

--- a/ask-sdk-core/tests/unit/test_attributes_manager.py
+++ b/ask-sdk-core/tests/unit/test_attributes_manager.py
@@ -74,9 +74,8 @@ class TestAttributesManager(unittest.TestCase):
             "new session request envelope")
 
     def test_get_session_attributes_from_out_of_session_request_envelope(self):
-        session = Session()
         request_envelope = RequestEnvelope(
-            version=None, session=session, context=None, request=None)
+            version=None, session=None, context=None, request=None)
         attributes_manager = AttributesManager(
             request_envelope=request_envelope)
 
@@ -143,9 +142,8 @@ class TestAttributesManager(unittest.TestCase):
             "AttributesManager fails to set the session attributes")
 
     def test_set_session_attributes_to_out_of_session_request_envelope(self):
-        session = Session()
         request_envelope = RequestEnvelope(
-            version=None, session=session, context=None, request=None)
+            version=None, session=None, context=None, request=None)
         attributes_manager = AttributesManager(
             request_envelope=request_envelope)
 

--- a/ask-sdk-core/tests/unit/test_skill_builder.py
+++ b/ask-sdk-core/tests/unit/test_skill_builder.py
@@ -196,6 +196,42 @@ class TestSkillBuilder(unittest.TestCase):
             "Response Envelope from lambda handler invocation has incorrect "
             "response than built by skill")
 
+    def test_out_of_session_lambda_handler_invocation(self):
+        mock_request_handler = mock.MagicMock(spec=AbstractRequestHandler)
+        mock_request_handler.can_handle.return_value = True
+        mock_response = Response()
+        mock_response.output_speech = "test output speech"
+        mock_request_handler.handle.return_value = mock_response
+        self.sb.add_request_handler(request_handler=mock_request_handler)
+
+        mock_request_envelope_payload = {
+            "context": {
+                "System": {
+                    "application": {
+                        "applicationId": "test"
+                    }
+                }
+            }
+        }
+
+        self.sb.skill_id = "test"
+        lambda_handler = self.sb.lambda_handler()
+
+        response_envelope = lambda_handler(
+            event=mock_request_envelope_payload, context=None)
+
+        assert response_envelope["version"] == RESPONSE_FORMAT_VERSION, (
+            "Response Envelope from lambda handler invocation has version "
+            "different than expected")
+        assert response_envelope["userAgent"] == user_agent_info(
+            sdk_version=__version__,
+            custom_user_agent=None), (
+            "Response Envelope from lambda handler invocation has user agent "
+            "info different than expected")
+        assert response_envelope["response"]["outputSpeech"] == "test output speech", (
+            "Response Envelope from lambda handler invocation has incorrect "
+            "response than built by skill")
+
 
 class TestCustomSkillBuilder(unittest.TestCase):
     def test_custom_persistence_adapter_default_null(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
An `AttributesManagerException` was being raised during `AttributesManager.__init__` (called every time a skill is invoked) if the incoming request had no session object. That was removed, as AudioPlayer callbacks have no session object.

## Motivation and Context
Again, at least AudioPlayer callbacks (presumably others?) have no session object.

## Testing
Ironically, in order to add this change several months ago, the existing "out-of-session" AttributeManager tests (which would have caught this error) had a `session=Session()` added to the request_envelope so they would (erroneously) pass. In addition to changing those back to `session=None`, a new test was added to test that out-of-session skill invocation was possible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
