### PR TITLE
Fix TimestampVerifier delta check

### DIFF
--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier.py
@@ -432,6 +432,6 @@ class TimestampVerifier(AbstractVerifier):
         """
         local_now = datetime.now(tz.tzutc())
         request_timestamp = deserialized_request_env.request.timestamp
-        if (abs((local_now - request_timestamp).seconds) >
+        if (abs((local_now - request_timestamp).total_seconds()) >
                 (self._tolerance_in_millis / 1000)):
             raise VerificationException("Timestamp verification failed")

--- a/ask-sdk-webservice-support/tests/unit/test_verifier.py
+++ b/ask-sdk-webservice-support/tests/unit/test_verifier.py
@@ -396,6 +396,23 @@ class TestTimestampVerifier(unittest.TestCase):
 
         self.assertIn("Timestamp verification failed", str(exc.exception))
 
+    def test_timestamp_verification_with_valid_future_server_timestamp(self):
+        valid_tolerance = int(DEFAULT_TIMESTAMP_TOLERANCE_IN_MILLIS / 2 / 1000)
+        valid_future_datetime = datetime.now(tzutc()) + timedelta(seconds=valid_tolerance)
+        test_request_envelope = RequestEnvelope(
+            request=IntentRequest(
+                timestamp=valid_future_datetime))
+        self.timestamp_verifier = TimestampVerifier()
+        try:
+            self.timestamp_verifier.verify(
+                headers={},
+                serialized_request_env="",
+                deserialized_request_env=test_request_envelope)
+        except:
+            # Should never reach here
+            raise self.fail(
+                "Timestamp verification failed for a valid input request")
+
     def test_timestamp_verification_with_valid_timestamp(self):
         test_request_envelope = RequestEnvelope(
             request=IntentRequest(


### PR DESCRIPTION
## Description
Requests should be handled if they fall +/- within a preset tolerance. Requests with (what should have been) a negative delta within the preset tolerance were raising an exception.

`timedelta.seconds` is always a positive integer. For `x - y`, if `x` is smaller (earlier) than `y`, you get "the number of seconds in a day minus the delta" instead of "a negative delta".

```
from datetime import datetime, timedelta
first = datetime.now()
second = datetime.now()
print((first - second).seconds)  # ~ 86397
print((first - second.total_seconds())  # ~ -2.497155
```

What was intended was most likely `timedelta.total_seconds()`, which returns a true (negative-possible float) delta.

## Motivation and Context
If the server's datetime is fractionally faster than the requests datetime, it'll raise a `ValidationException`. Unlikely, but possible (happened to me during testing for the first time last week).

## Testing
See above code, and new test.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
