### PR TITLE
Fixed broken URL links

### DIFF
--- a/ask-sdk-core/README.rst
+++ b/ask-sdk-core/README.rst
@@ -40,13 +40,13 @@ Usage and Getting Started
 -------------------------
 
 Getting started guides, SDK Features, API references, samples etc. can
-be found at `Read The Docs <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>`_
+be found at ``Read The Docs`` <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>
 
 
 Got Feedback?
 -------------
 
 - We would like to hear about your bugs, feature requests, questions or quick feedback.
-  Please search for the `existing issues <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues>`_ before opening a new one. It would also be helpful
-  if you follow the templates for issue and pull request creation. Please follow the `contributing guidelines <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>`_!!
-- Request and vote for `Alexa features <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>`_!
+  Please search for the ``existing issues`` <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues> before opening a new one. It would also be helpful
+  if you follow the templates for issue and pull request creation. Please follow the ``contributing guidelines`` <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>!
+- Request and vote for ``Alexa features`` <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>!

--- a/ask-sdk-core/README.rst
+++ b/ask-sdk-core/README.rst
@@ -40,13 +40,13 @@ Usage and Getting Started
 -------------------------
 
 Getting started guides, SDK Features, API references, samples etc. can
-be found at `Read The Docs <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>`
+be found at `Read The Docs <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>`_
 
 
 Got Feedback?
 -------------
 
 - We would like to hear about your bugs, feature requests, questions or quick feedback.
-  Please search for the `existing issues <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues>` before opening a new one. It would also be helpful
-  if you follow the templates for issue and pull request creation. Please follow the `contributing guidelines <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>`!
-- Request and vote for `Alexa features <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>`!
+  Please search for the `existing issues <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues>`_ before opening a new one. It would also be helpful
+  if you follow the templates for issue and pull request creation. Please follow the `contributing guidelines <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>`_!
+- Request and vote for `Alexa features <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>`_!

--- a/ask-sdk-core/README.rst
+++ b/ask-sdk-core/README.rst
@@ -1,4 +1,4 @@
- ====================================================
+====================================================
 ASK SDK Core - Base components of Python ASK SDK
 ====================================================
 
@@ -40,13 +40,13 @@ Usage and Getting Started
 -------------------------
 
 Getting started guides, SDK Features, API references, samples etc. can
-be found at ``Read The Docs`` <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>
+be found at `Read The Docs <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>`
 
 
 Got Feedback?
 -------------
 
 - We would like to hear about your bugs, feature requests, questions or quick feedback.
-  Please search for the ``existing issues`` <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues> before opening a new one. It would also be helpful
-  if you follow the templates for issue and pull request creation. Please follow the ``contributing guidelines`` <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>!
-- Request and vote for ``Alexa features`` <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>!
+  Please search for the `existing issues <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues>` before opening a new one. It would also be helpful
+  if you follow the templates for issue and pull request creation. Please follow the `contributing guidelines <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>`!
+- Request and vote for `Alexa features <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>`!


### PR DESCRIPTION
Incorrect reStructuredText was breaking most of the URLs preventing someone from clicking on the link (characters %3E%60 were added to the hyperlink).

## Description
Incorrect reStructuredText was breaking most of the URLs preventing someone from clicking on the link (characters %3E%60 were added to the hyperlink).

## Motivation and Context
Anyone that wants to learn more about the SDK via the links in the Readme will need to copy the URL text instead of clicking on the link because of the incorrect reStructuredText, which was added invalid characters to the hyperlink.

## Testing
Changes were made to the reStructuredText to align with guidelines; previewed changes.

## Screenshots (if appropriate)
n/a

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ x] I have updated the documentation accordingly
- [ x] I have read the **README** document
- [ x] I have added tests to cover my changes
- [ x] All new and existing tests passed

## License
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
