### PR TITLE
Fix class name in example in README

### DIFF
--- a/ask-smapi-sdk/README.rst
+++ b/ask-smapi-sdk/README.rst
@@ -57,8 +57,9 @@ Use the ``Client ID``, ``Client Secret`` and ``Refresh Token`` retrieved in the 
 
 .. code-block:: python
 
-    from ask_smapi_sdk import StandardSmapiBuilder
-    smapi_client = StandardSmapiBuilder(client_id='Client ID', client_secret='Client Secret Key', refresh_token='Refresh Token').client()
+    from ask_smapi_sdk import StandardSmapiClientBuilder
+    smapi_client_builder = StandardSmapiClientBuilder(client_id='Client ID', client_secret='Client Secret Key', refresh_token='Refresh Token')
+    smapi_client = smapi_client_builder.client()
 
 
 Usage Examples


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Imported class name was incorrect, missing "Client" in the name.

`.client()` is easy to miss "beyond the fold" at the end of a long line of code, I moved it to the next line.

## Motivation and Context
Can't import the Class with the wrong name.

## Testing
Tests already existed. The example in the README was just misspelled. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
