### PR TITLE
Retrieve case-insensitive header values

### DIFF
--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier.py
@@ -187,8 +187,13 @@ class RequestVerifier(AbstractVerifier):
         :raises: :py:class:`VerificationException` if headers doesn't
             exist or verification fails
         """
-        cert_url = headers.get(self._signature_cert_chain_url_key)
-        signature = headers.get(self._signature_key)
+        cert_url = None
+        signature = None
+        for header_key, header_value in six.iteritems(headers):
+            if header_key.lower() == self._signature_cert_chain_url_key.lower():
+                cert_url = header_value
+            elif header_key.lower() == self._signature_key.lower():
+                signature = header_value
 
         if cert_url is None or signature is None:
             raise VerificationException(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since header keys can be case-insensitive as per the [RFC 2616 doc](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), we need to retrieve them correctly before retrieving the certificate for request verification.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
#136 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
tox tests ran successfully. Travis seems to fail because of invalid Python version on Macos new xcode package. Will check as per another PR.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
