### PR TITLE
Change maximum timestamp verifier tolerance values as per guidelines

### DIFF
--- a/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier_constants.py
+++ b/ask-sdk-webservice-support/ask_sdk_webservice_support/verifier_constants.py
@@ -51,10 +51,17 @@ CERT_CHAIN_DOMAIN = "echo-api.amazon.com"
 #: Character encoding used in the request.
 CHARACTER_ENCODING = "utf-8"
 
-#: Default allowable tolerance in request timestamp.
-#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-timestamp>`__.
-DEFAULT_TIMESTAMP_TOLERANCE_IN_MILLIS = 150000
-
 #: Maximum allowable tolerance in request timestamp.
+#: For more info, check `link <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#check-request-timestamp>`__.
+MAX_NORMAL_REQUEST_TOLERANCE_IN_MILLIS = 150000
+
+#: Maximum allowable tolerance for skill events in request timestamp.
 #: For more info, check `link <https://developer.amazon.com/docs/smapi/skill-events-in-alexa-skills.html#delivery-of-events-to-the-skill>`__.
-MAX_TIMESTAMP_TOLERANCE_IN_MILLIS = 3600000
+MAX_SKILL_EVENT_TOLERANCE_IN_MILLIS = 3600000
+
+#: Skill events that can have max timestamp tolerance values of an hour
+ALEXA_SKILL_EVENT_LIST = {'AlexaSkillEvent.SkillEnabled',
+                          'AlexaSkillEvent.SkillDisabled',
+                          'AlexaSkillEvent.SkillPermissionChanged',
+                          'AlexaSkillEvent.SkillPermissionAccepted',
+                          'AlexaSkillEvent.SkillAccountLinked'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Decouples the verification tolerances for standard skill requests and skill event requests which have different maximums.

## Motivation and Context
Due to the delivery characteristics of skill event requests, these requests may arrive with a timestamp value of up to 1 hour prior to the current time and are verified against a different upper bound value than standard requests.

Standard requests should be verified within 150 seconds. This change splits the verification logic of the two request classes.

https://developer.amazon.com/en-US/docs/alexa/smapi/skill-events-in-alexa-skills.html#delivery-of-events-to-the-skill

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Unit tests added. Existing tests pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
