### PR TITLE
feat: Adding Directive support for RePrompt SPI

### DIFF
--- a/ask-sdk-core/ask_sdk_core/response_helper.py
+++ b/ask-sdk-core/ask_sdk_core/response_helper.py
@@ -17,16 +17,17 @@
 #
 
 import typing
+
 from ask_sdk_model import Response
-from ask_sdk_model.ui import SsmlOutputSpeech, Reprompt
-from ask_sdk_model.interfaces.display import (
-    TextContent, PlainText, RichText)
+from ask_sdk_model.interfaces.display import PlainText, RichText, TextContent
+from ask_sdk_model.ui import Reprompt, SsmlOutputSpeech
 
 if typing.TYPE_CHECKING:
     from typing import Union
+
     from ask_sdk_model import Directive
-    from ask_sdk_model.ui import Card
     from ask_sdk_model.canfulfill import CanFulfillIntent
+    from ask_sdk_model.ui import Card
     from ask_sdk_model.ui.play_behavior import PlayBehavior
 
 
@@ -130,6 +131,25 @@ class ResponseFactory(object):
                 directive.object_type == "VideoApp.Launch"):
             self.response.should_end_session = None
         self.response.directives.append(directive)
+        return self
+
+    def add_directive_to_reprompt(self, directive):
+        # type: (Directive) -> 'ResponseFactory'
+        """Adds directive to reprompts.
+
+        :param directive: the directive sent back to Alexa device.
+        :type directive: ask_sdk_model.directive.Directive
+        :return: response factory with partial response being built and
+            access from self.response.
+        :rtype: ResponseFactory
+        """
+        if self.response.reprompt is None:
+            self.response.reprompt = Reprompt(directives=[])
+
+        if self.response.reprompt.directives is not None:
+            self.response.reprompt.directives.append(directive)
+
+        self.set_should_end_session(False)
         return self
 
     def set_should_end_session(self, should_end_session):

--- a/ask-sdk-core/tests/unit/test_response_helper.py
+++ b/ask-sdk-core/tests/unit/test_response_helper.py
@@ -18,19 +18,22 @@
 
 import unittest
 
-from ask_sdk_model.interfaces.videoapp import LaunchDirective, VideoItem, Metadata
-from ask_sdk_model.ui import SsmlOutputSpeech, Reprompt
-from ask_sdk_model.interfaces.display import TextContent
-from ask_sdk_model.interfaces.display import PlainText
-from ask_sdk_model.interfaces.display import RichText
-from ask_sdk_model.canfulfill import (
-    CanFulfillIntent, CanFulfillIntentValues, CanFulfillSlot,
-    CanFulfillSlotValues, CanUnderstandSlotValues)
+from ask_sdk_core.response_helper import (PLAIN_TEXT_TYPE, RICH_TEXT_TYPE,
+                                          ResponseFactory,
+                                          get_plain_text_content,
+                                          get_rich_text_content,
+                                          get_text_content)
+from ask_sdk_model import directive
+from ask_sdk_model.canfulfill import (CanFulfillIntent, CanFulfillIntentValues,
+                                      CanFulfillSlot, CanFulfillSlotValues,
+                                      CanUnderstandSlotValues)
+from ask_sdk_model.interfaces.display import PlainText, RichText, TextContent
+from ask_sdk_model.interfaces.videoapp import (LaunchDirective, Metadata,
+                                               VideoItem)
+from ask_sdk_model.response import Response
+from ask_sdk_model.ui import (Reprompt, SsmlOutputSpeech, output_speech,
+                              reprompt, ssml_output_speech)
 from ask_sdk_model.ui.play_behavior import PlayBehavior
-
-from ask_sdk_core.response_helper import (
-    ResponseFactory, get_text_content, get_plain_text_content,
-    get_rich_text_content, PLAIN_TEXT_TYPE, RICH_TEXT_TYPE)
 
 
 class TestResponseFactory(unittest.TestCase):
@@ -117,6 +120,25 @@ class TestResponseFactory(unittest.TestCase):
         assert len(response_factory.response.directives) == 2, (
             "The add_directive method of ResponseFactory fails to add "
             "multiple directives")
+
+    def test_add_reprompt_directive(self):
+        response_factory = self.response_factory.add_directive_to_reprompt(directive=None)
+
+        assert len(response_factory.response.reprompt.directives) == 1, (
+            "The add_directive_to_reprompt method of ResponseFactory fails "
+            "to add directive"
+        )
+
+    def test_response_with_reprompt_directive(self):
+        expected_response = Response(
+            output_speech=SsmlOutputSpeech(ssml="<speak>Hello World</speak>"),
+            reprompt=Reprompt(directives=['Alexa.Presentation.APLA.RenderDocument']),
+            should_end_session=False)
+
+        response_factory = self.response_factory.set_should_end_session(True).add_directive_to_reprompt(
+            directive='Alexa.Presentation.APLA.RenderDocument').speak('Hello World')
+        assert response_factory.response == expected_response, (
+            "The add_directive_to_reprompt method of ResponseFactory fails to add directive")
 
     def test_add_video_app_launch_directive(self):
         directive = LaunchDirective(video_item=VideoItem(

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,9 @@ commands =
     python -m pip install --upgrade pip
     python -m pip install --upgrade wheel
     py{36,37,38}: python -m pip install --upgrade mypy
+    python -m pip install types-python-dateutil
+    python -m pip install types-requests
+    python -m pip install types-six
     {toxinidir}/scripts/ci/sdk_install
     {toxinidir}/scripts/ci/run_tests
     py{36,37,38}: mypy ask-sdk/ask_sdk
@@ -57,6 +60,9 @@ commands =
     python -m pip install --upgrade pip
     python -m pip install --upgrade wheel
     py{36,37,38}: python -m pip install --upgrade mypy
+    python -m pip install types-python-dateutil
+    python -m pip install types-requests
+    python -m pip install types-six
     python {toxinidir}\scripts\ci\sdk_install
     python {toxinidir}\scripts\ci\run_tests
     mypy ask-sdk\ask_sdk


### PR DESCRIPTION
## Description
 - Adding Directive support for RePrompt SPI, 
 - Created `add_directive_to_reprompt` method in Response helper and added new test cases 

## Testing
- nosetests tests success with latest model release

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
