### PR TITLE
Update Django-specific signature header to Signature-256

### DIFF
--- a/django-ask-sdk/django_ask_sdk/skill_adapter.py
+++ b/django-ask-sdk/django_ask_sdk/skill_adapter.py
@@ -47,7 +47,7 @@ SIGNATURE_CERT_CHAIN_URL_KEY = "HTTP_SIGNATURECERTCHAINURL"
 #: the `header key <https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html#checking-the-signature-of-the-request>`__
 #: provided by Alexa, because of Django's HTTP
 #: `Meta headers <https://docs.djangoproject.com/en/2.1/ref/request-response/#django.http.HttpRequest.META>`__.
-SIGNATURE_KEY = "HTTP_SIGNATURE"
+SIGNATURE_KEY = "HTTP_SIGNATURE_256"
 
 logger = logging.getLogger("django.ask-sdk")
 

--- a/django-ask-sdk/requirements.txt
+++ b/django-ask-sdk/requirements.txt
@@ -1,2 +1,2 @@
-ask-sdk-webservice-support>=0.1.0
+ask-sdk-webservice-support>=1.3.3
 django>=2.0


### PR DESCRIPTION
## Description
Updates the Django-specific signature header to use SHA-256 rather than SHA-1 in order to remain compatible with the changes from @doiron in #200 .


## Motivation and Context
This fixes the bug highlighted in #202 and allows django_ask_sdk to be used with the latest ask-sdk-webservice-support


## Testing
Tested on a skill I host. Allows the skill to be used with the other changes in the latest version of the django_ask_sdk


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
